### PR TITLE
feat: add basic xml handling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please refer to the linked documentation for instructions on how to get started 
 ## Not Implemented
 
 - Support for the [(beta) document translation endpoint](https://www.deepl.com/docs-api/translating-documents/).
-- Support for the [XML handling flags](https://www.deepl.com/docs-api/translating-text/) in the translation endpoint.
+- Support for advanced parameters of [Handling XML](https://www.deepl.com/docs-api/handling-xml/) in the translation endpoint (outline_detection, splitting_tags, non_splitting_tags, ignore_tags).
 
 ## See Also
 

--- a/deepl_api/__init__.py
+++ b/deepl_api/__init__.py
@@ -171,6 +171,7 @@ class DeepL:
         split_sentences: SplitSentences = None,
         preserve_formatting: bool = None,
         formality: Formality = None,
+        handle_xml: bool = None,
         texts: list,
     ) -> list:
         """
@@ -208,6 +209,9 @@ class DeepL:
 
         if formality != None:
             payload["formality"] = formality.value
+        
+        if handle_xml:
+            payload["tag_handling"] = "xml"
 
         data = self._api_call("/translate", payload)
 

--- a/deepl_api/cli.py
+++ b/deepl_api/cli.py
@@ -66,6 +66,7 @@ def languages():
 @click.option("-p", "--preserve-formatting", default=None, is_flag=True)
 @click.option("-m", "--formality-more", default=None, is_flag=True)
 @click.option("-l", "--formality-less", default=None, is_flag=True)
+@click.option("-x", "--handle-xml", default=None, is_flag=True)
 def translate(
     source_language,
     target_language,
@@ -74,6 +75,7 @@ def translate(
     preserve_formatting,
     formality_more,
     formality_less,
+    handle_xml
 ):
     try:
         deepl = _get_instance()
@@ -94,6 +96,7 @@ def translate(
             target_language=target_language,
             preserve_formatting=preserve_formatting,
             formality=formality,
+            handle_xml=handle_xml,
             texts=[text],
         )
 

--- a/tests/test_deepl_api.py
+++ b/tests/test_deepl_api.py
@@ -102,6 +102,33 @@ def test_translate():
                 },
             ],
         },
+        {
+            "args": {
+                "source_language": "EN",
+                "target_language": "FR",
+                "handle_xml": True,
+                "texts": ["A delicious <i>apple</i>."],
+            },
+            "result": [
+                {
+                    "detected_source_language": "EN",
+                    "text": "Une <i>pomme</i> délicieuse.",
+                },
+            ],
+        },
+        {
+            "args": {
+                "source_language": "EN",
+                "target_language": "FR",
+                "texts": ["A delicious <i>apple</i>."],
+            },
+            "result": [
+                {
+                    "detected_source_language": "EN",
+                    "text": "Une délicieuse <i>pomme</i>.",
+                },
+            ],
+        },
     ]
 
     for test in tests:


### PR DESCRIPTION
Here's what I'm using right now to work with the XML handling. It's just the main XML handling flag, none of the sub-options yet. My thinking is this would serve many XML use cases in the meantime, and would be compatible with our eventual sub-options (if we keep handle_xml as a root-level parameter and encapsulate the sub-options).

I understand if you want to hold off until the implementation plan for the XML sub-options is more concrete though (perhaps all XML options including the main on/off flag should be encapsulated together?).

Notes:
- I set the XML option up as a boolean, as the only values in the DeepL API for `tag_handling` are `xml` or `off`. Boolean flag seemed like better UX than asking people to supply the full `tag_handling=xml`. Some danger of future API changes expanding the set of possible values though.
- My second test may be overkill, it's in there mostly to document how things should be different when we're _not_ asking DeepL to handle the XML tags.
- I noticed the CLI tests didn't include things like Formality etc, so I didn't write an XML test for CLI

This is my first open source PR so any feedback on the code or PR procedures is welcome!